### PR TITLE
Fix: Initialize(): nil ptr deref with not handled err

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -44,25 +44,24 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 	callbacks.RegisterDefaultCallbacks(db, &callbacks.Config{
 		WithReturning: true,
 	})
-
 	if dialector.Conn != nil {
 		db.ConnPool = dialector.Conn
 	} else {
 		var config *pgx.ConnConfig
 
 		config, err = pgx.ParseConfig(dialector.Config.DSN)
+		if err != nil {
+			return
+		}
 		if dialector.Config.PreferSimpleProtocol {
 			config.PreferSimpleProtocol = true
 		}
-
 		result := regexp.MustCompile("(time_zone|TimeZone)=(.*)($|&| )").FindStringSubmatch(dialector.Config.DSN)
 		if len(result) > 2 {
 			config.RuntimeParams["timezone"] = result[2]
 		}
-
 		db.ConnPool = stdlib.OpenDB(*config)
 	}
-
 	return
 }
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x16e87b1]

goroutine 1 [running]:
gorm.io/driver/postgres.Dialector.Initialize(0xc00026d5e0, 0xc00058ec60, 0x1a6d660, 0xc00058ecc0)
        /home/user/.go/pkg/mod/gorm.io/driver/postgres@v0.2.6/postgres.go:63 +0x171
gorm.io/gorm.Open(0x1d0c800, 0xc000693168, 0xc0000a8d00, 0x0, 0x270dac0, 0x7fc2b93a2e98)
        /home/user/.go/pkg/mod/gorm.io/gorm@v0.2.24/gorm.go:108 +0x7d6
gitlab.com/org/app/user/internal/db/user.New(0xc000387f60, 0xc000387f60, 0x0, 0x193c860)
        /home/user/ws/org/user/internal/db/user/user.go:29 +0xdb
gitlab.com/org/app/internal/handler/user.NewHandler(0xc000693160, 0x0, 0x0, 0x0)
        /home/user/ws/org/user/internal/handler/user/handler.go:31 +0x11b
main.main()
        /home/user/ws/org/user/cmd/user/main.go:23 +0xff
```

### User Case Description

Fix Panic(nil ptr deref/non-handled err).
