### PR TITLE
Fix Postgres types used to store signed integers

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -113,20 +113,24 @@ func (dialector Dialector) DataTypeOf(field *schema.Field) string {
 	case schema.Bool:
 		return "boolean"
 	case schema.Int, schema.Uint:
+		size := field.Size
+		if field.DataType == schema.Uint {
+			size++
+		}
 		if field.AutoIncrement {
 			switch {
-			case field.Size < 16:
+			case size <= 16:
 				return "smallserial"
-			case field.Size < 31:
+			case size <= 32:
 				return "serial"
 			default:
 				return "bigserial"
 			}
 		} else {
 			switch {
-			case field.Size < 16:
+			case size <= 16:
 				return "smallint"
-			case field.Size < 31:
+			case size <= 32:
 				return "integer"
 			default:
 				return "bigint"


### PR DESCRIPTION

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
`bigint` is currently used to store Go `int32` in Postgres. `integer` should
suffice for the range, and it is the recommended default as "it offers the best
balance between range, storage size, and performance": https://www.postgresql.org/docs/10/datatype-numeric.html

Related to: https://github.com/go-gorm/gorm/pull/1536

<!--
provide a general description of the code changes in your pull request
-->