### PR TITLE
implement Migrator.ColumnTypes

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -201,13 +201,15 @@ func (m Migrator) HasConstraint(value interface{}, name string) bool {
 	return count > 0
 }
 
-func (m Migrator) ColumnTypes(value interface{}) (columnTypes []Column, err error) {
-	columnTypes = make([]Column, 0)
+func (m Migrator) ColumnTypes(value interface{}) (columnTypes []gorm.ColumnType, err error) {
+	columnTypes = make([]gorm.ColumnType, 0)
 	err = m.RunWithValue(value, func(stmt *gorm.Statement) error {
+		currentDatabase := m.DB.Migrator().CurrentDatabase()
 		columns, err := m.DB.Raw(
 			"SELECT column_name, is_nullable, udt_name, character_maximum_length, "+
 				"numeric_precision, numeric_precision_radix, numeric_scale "+
-				"FROM information_schema.columns WHERE table_schema = CURRENT_SCHEMA() AND table_name = ?", stmt.Table).Rows()
+				"FROM information_schema.columns WHERE table_schema = ? AND table_name = ?",
+			currentDatabase, stmt.Table).Rows()
 		if err != nil {
 			return err
 		}

--- a/migrator.go
+++ b/migrator.go
@@ -207,7 +207,7 @@ func (m Migrator) ColumnTypes(value interface{}) (columnTypes []Column, err erro
 		columns, err := m.DB.Raw(
 			"SELECT column_name, is_nullable, udt_name, character_maximum_length, "+
 				"numeric_precision, numeric_precision_radix, numeric_scale "+
-				"FROM information_schema.columns WHERE table_name = ?", stmt.Table).Rows()
+				"FROM information_schema.columns WHERE table_schema = CURRENT_SCHEMA() AND table_name = ?", stmt.Table).Rows()
 		if err != nil {
 			return err
 		}

--- a/migrator.go
+++ b/migrator.go
@@ -216,28 +216,20 @@ func (m Migrator) ColumnTypes(value interface{}) (columnTypes []gorm.ColumnType,
 		defer columns.Close()
 
 		for columns.Next() {
-			var (
-				name      string
-				nullable  sql.NullString
-				datatype  string
-				maxlen    sql.NullInt64
-				precision sql.NullInt64
-				radix     sql.NullInt64
-				scale     sql.NullInt64
+			var column Column
+			err = columns.Scan(
+				&column.name,
+				&column.nullable,
+				&column.datatype,
+				&column.maxlen,
+				&column.precision,
+				&column.radix,
+				&column.scale,
 			)
-			err = columns.Scan(&name, &nullable, &datatype, &maxlen, &precision, &radix, &scale)
 			if err != nil {
 				return err
 			}
-			columnTypes = append(columnTypes, Column{
-				name:      name,
-				nullable:  nullable,
-				datatype:  datatype,
-				maxlen:    maxlen,
-				precision: precision,
-				radix:     radix,
-				scale:     scale,
-			})
+			columnTypes = append(columnTypes, column)
 		}
 
 		return err


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested
- [ ] Update `gorm` version in `go.mod` on next tag

### What did this pull request do?

Implement `ColumnTypes` for `postgres`.

Information for each column type is taken from the `information_schema.columns` table:

- `column_name` is the name of the column
- `is_nullable` is a (nullable) string, equal to `YES` if nullable, `NO` if `not_null`
- `udt_name` is the (short) name of the type (e.g., `varchar` for `character varying`)
- `character_maximum_length` is the (nullable) max length of character columns
- `numeric_precision` is the (nullable) precision of numeric columns
- `numeric_precision_radix` is the (nullable) radix used for precision for numeric columns, and it's equal to `10` for numeric columns, `2` for integer columns
- `numeric_scale` is the (nullable) scale of numeric columns

[This PR](https://github.com/go-gorm/playground/pull/183) runs the tests that broke before this change using this fork.

### User Case Description

`AutoMigrate` was not detecting `not null` to `nullable` column changes on `postgres` (and viceversa, `nullable` to `not null`), see [this issue](https://github.com/go-gorm/gorm/issues/3628).
