### PR TITLE
fix table schema and table catalog mixup

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -208,7 +208,7 @@ func (m Migrator) ColumnTypes(value interface{}) (columnTypes []gorm.ColumnType,
 		columns, err := m.DB.Raw(
 			"SELECT column_name, is_nullable, udt_name, character_maximum_length, "+
 				"numeric_precision, numeric_precision_radix, numeric_scale "+
-				"FROM information_schema.columns WHERE table_schema = ? AND table_name = ?",
+				"FROM information_schema.columns WHERE table_schema = CURRENT_SCHEMA() and table_catalog = ? AND table_name = ?",
 			currentDatabase, stmt.Table).Rows()
 		if err != nil {
 			return err


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

My previous PR mixed up `table_schema` and `table_catalog`. In `postgres`, the current database is stored in `table_catalog`, while in `mysql` it's stored in `table_schema`. I mixed them up while opening the two PRs.

Right now, the`ColumnTypes` implementation for `postgres` returns an empty list of columns. This PR fixes this.

The tests I were running were not covering the case where no column was found. I fixed them here: https://github.com/go-gorm/playground/pull/183

I'm sorry for the mistake.