### PR TITLE
retrieve timestamp precision from DB

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -150,6 +150,9 @@ func (dialector Dialector) DataTypeOf(field *schema.Field) string {
 		}
 		return "text"
 	case schema.Time:
+		if field.Precision > 0 {
+			return fmt.Sprintf("timestamptz(%d)", field.Precision)
+		}
 		return "timestamptz"
 	case schema.Bytes:
 		return "bytea"


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Precision for timestamps is stored in the `datetime_precision` column of `information_schema.columns`.
This PR takes the `datetime_precision` and returns it from the `DecimalPrecision` function.

There is also a fix for the `DataTypeOf` function: the `precision` was not taken into account when creating a new datetime column.