### PR TITLE
Fix DSN dbname parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ import (
 )
 
 // https://github.com/jackc/pgx
-dsn := "host=localhost user=gorm password=gorm DB.name=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
+dsn := "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
 ```
 
@@ -22,7 +22,7 @@ import (
 )
 
 db, err := gorm.Open(postgres.New(postgres.Config{
-  DSN: "host=localhost user=gorm password=gorm DB.name=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai", // data source name, refer https://github.com/jackc/pgx
+  DSN: "host=localhost user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai", // data source name, refer https://github.com/jackc/pgx
   PreferSimpleProtocol: true, // disables implicit prepared statement usage. By default pgx automatically uses the extended protocol
 }), &gorm.Config{})
 ```


### PR DESCRIPTION
Should use `dbname`, see https://pkg.go.dev/github.com/jackc/pgconn#ParseConfig