### PR TITLE
Fix migrator.go with multiple schemas with same dataset

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -243,7 +243,7 @@ func (m Migrator) MigrateColumn(value interface{}, field *schema.Field, columnTy
 		var description string
 		values := []interface{}{stmt.Table, field.DBName, stmt.Table, m.CurrentSchema(stmt)}
 		checkSQL := "SELECT description FROM pg_catalog.pg_description "
-		checkSQL += "WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = ? AND column_name = ?) "
+		checkSQL += "WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_schema=CURRENT_SCHEMA() and table_name = ? AND column_name = ?) "
 		checkSQL += "AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = ? AND relnamespace = "
 		checkSQL += "(SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = ?))"
 		m.DB.Raw(checkSQL, values...).Scan(&description)


### PR DESCRIPTION

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
Fix migrator.go with multiple schemas with same dataset

### User Case Description

<!-- Your use case -->
If you have a database with multiple schemas with the same tables, when you run migrator, it executes this query:

```
SELECT description 
FROM pg_catalog.pg_description 
WHERE objsubid = (SELECT ordinal_position 
                  FROM information_schema.columns 
                  WHERE table_name = 'my-table' AND column_name = 'created_at') 
AND objoid = (SELECT oid 
              FROM pg_catalog.pg_class 
              WHERE relname = 'my-table' 
              AND relnamespace = (SELECT oid 
                                  FROM pg_catalog.pg_namespace 
                                  WHERE nspname = CURRENT_SCHEMA())
             )
```
and it is wrong because the first subquery return a multiple choice and query fails with this error: 
```
gorm.io/driver/postgres@v1.0.8/migrator.go:249 ERROR: more than one row returned by a subquery used as an expression (SQLSTATE 21000); ERROR: more than one row returned by a subquery used as an expression (SQLSTATE 21000)
```
For example, with this database:
- DB
   - schemas
       - yoigo
           - tables
              - credentials 
       - pepephone
           - tables
              - credentials 
       - masmovil
           - tables
              - credentials 
       - public
           - tables
              - credentials 
              
The migrator fails because there are multiple schemas with the same credentials table.

The correct query is this, including **table_schema=CURRENT_SCHEMA()**:
```
SELECT description 
FROM pg_catalog.pg_description 
WHERE objsubid = (SELECT ordinal_position 
                  FROM information_schema.columns 
                  WHERE table_schema=CURRENT_SCHEMA() and table_name = 'credentials' AND column_name = 'created_at') 
AND objoid = (SELECT oid 
              FROM pg_catalog.pg_class 
              WHERE relname = 'credentials' 
              AND relnamespace = (SELECT oid 
                                  FROM pg_catalog.pg_namespace 
                                  WHERE nspname = CURRENT_SCHEMA())
             )

```
