### PR TITLE
Statement cache build function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module gorm.io/driver/postgres
 go 1.14
 
 require (
+	github.com/jackc/pgconn v1.8.1
 	github.com/jackc/pgx/v4 v4.11.0
 	gorm.io/gorm v1.21.9
 )

--- a/postgres.go
+++ b/postgres.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgconn/stmtcache"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/stdlib"
 	"gorm.io/gorm"
@@ -26,6 +28,7 @@ type Config struct {
 	DSN                  string
 	PreferSimpleProtocol bool
 	WithoutReturning     bool
+	StmtCacheFunc        func(conn *pgconn.PgConn) stmtcache.Cache
 	Conn                 *sql.DB
 }
 
@@ -60,6 +63,9 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 		}
 		if dialector.Config.PreferSimpleProtocol {
 			config.PreferSimpleProtocol = true
+		}
+		if dialector.Config.StmtCacheFunc != nil {
+			config.BuildStatementCache = dialector.Config.StmtCacheFunc
 		}
 		result := regexp.MustCompile("(time_zone|TimeZone)=(.*?)($|&| )").FindStringSubmatch(dialector.Config.DSN)
 		if len(result) > 2 {


### PR DESCRIPTION
- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

This PR adds the option to pass a configuration function to the `dialector config`.

### User Case Description

I'm using go-gorm Postgres driver with AWS RDS Proxy and two errors happen all the time - missing prepared statement (SQLSTATE 26000) and statement already exists (SQLSTATE 42P05). The solution is mentioned [by jackc here](https://github.com/jackc/pgx/issues/602#issuecomment-532236718).

Example usage:
```go
db, err := gorm.Open(postgres.New(postgres.Config{
	DSN: connStr, // data source name, refer https://github.com/jackc/pgx
	StmtCacheFunc: func(conn *pgconn.PgConn) stmtcache.Cache {
		return stmtcache.New(conn, stmtcache.ModeDescribe, 1024)
	},
}), &gorm.Config{})

```