### PR TITLE
fix: calling Migrator.HasTable() when the DB is offline would cause a panic

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -65,7 +65,7 @@ func (c Column) DecimalSize() (precision int64, scale int64, ok bool) {
 }
 
 func (m Migrator) CurrentDatabase() (name string) {
-	m.DB.Raw("SELECT CURRENT_DATABASE()").Row().Scan(&name)
+	m.DB.Raw("SELECT CURRENT_DATABASE()").Scan(&name)
 	return
 }
 
@@ -97,7 +97,7 @@ func (m Migrator) HasIndex(value interface{}, name string) bool {
 		currentSchema, curTable := m.CurrentSchema(stmt, stmt.Table)
 		return m.DB.Raw(
 			"SELECT count(*) FROM pg_indexes WHERE tablename = ? AND indexname = ? AND schemaname = ?", curTable, name, currentSchema,
-		).Row().Scan(&count)
+		).Scan(&count).Error
 	})
 
 	return count > 0
@@ -185,9 +185,8 @@ func (m Migrator) HasTable(value interface{}) bool {
 	var count int64
 	m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		currentSchema, curTable := m.CurrentSchema(stmt, stmt.Table)
-		return m.DB.Raw("SELECT count(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ? AND table_type = ?", currentSchema, curTable, "BASE TABLE").Row().Scan(&count)
+		return m.DB.Raw("SELECT count(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ? AND table_type = ?", currentSchema, curTable, "BASE TABLE").Scan(&count).Error
 	})
-
 	return count > 0
 }
 
@@ -235,7 +234,7 @@ func (m Migrator) HasColumn(value interface{}, field string) bool {
 		return m.DB.Raw(
 			"SELECT count(*) FROM INFORMATION_SCHEMA.columns WHERE table_schema = ? AND table_name = ? AND column_name = ?",
 			currentSchema, curTable, name,
-		).Row().Scan(&count)
+		).Scan(&count).Error
 	})
 
 	return count > 0
@@ -284,7 +283,7 @@ func (m Migrator) HasConstraint(value interface{}, name string) bool {
 		return m.DB.Raw(
 			"SELECT count(*) FROM INFORMATION_SCHEMA.table_constraints WHERE table_schema = ? AND table_name = ? AND constraint_name = ?",
 			currentSchema, curTable, name,
-		).Row().Scan(&count)
+		).Scan(&count).Error
 	})
 
 	return count > 0


### PR DESCRIPTION

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

fix: calling Migrator.HasTable() when the DB is offline would cause a panic. 

the panic looked like:
```
panic: runtime error: invalid memory address or nil pointer dereference
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc40d76]

goroutine 1 [running]:
database/sql.(*Rows).close(0x0, 0x0, 0x0, 0x0, 0x0)
	/opt/hostedtoolcache/go/1.15.13/x64/src/database/sql/sql.go:3155 +0x76
database/sql.(*Rows).Close(0x0, 0x0, 0x0)
	/opt/hostedtoolcache/go/1.15.13/x64/src/database/sql/sql.go:3151 +0x33
panic(0x14645a0, 0x218ded0)
	/opt/hostedtoolcache/go/1.15.13/x64/src/runtime/panic.go:969 +0x1b9
database/sql.(*Rows).Next(0x0, 0x1653226)
	/opt/hostedtoolcache/go/1.15.13/x64/src/database/sql/sql.go:2835 +0x30
database/sql.(*Row).Scan(0xc0002f46e0, 0xc0001ccd10, 0x1, 0x1, 0x0, 0x0)
	/opt/hostedtoolcache/go/1.15.13/x64/src/database/sql/sql.go:3221 +0xf6
gorm.io/driver/postgres.Migrator.HasTable.func1(0xc00050d1e0, 0xc00050d1e0, 0x8)
	/home/runner/go/pkg/mod/gorm.io/driver/postgres@v1.0.8/migrator.go:183 +0x17b
gorm.io/gorm/migrator.Migrator.RunWithValue(0x13bba01, 0xc0002981e0, 0x18af280, 0xc000205710, 0x13bc480, 0xc000531e80, 0xc0001ccdf0, 0x7f9a0c5a06b0, 0x8)
	/home/runner/go/pkg/mod/gorm.io/gorm@v1.21.7/migrator/migrator.go:49 +0xd6
gorm.io/driver/postgres.Migrator.HasTable(0x1, 0xc0002981e0, 0x18af280, 0xc000205710, 0x13bc480, 0xc000531e80, 0xc000531e80)
	/home/runner/go/pkg/mod/gorm.io/driver/postgres@v1.0.8/migrator.go:182 +0xda
github.com/go-gormigrate/gormigrate/v2.(*Gormigrate).createMigrationTableIfNotExists(0xc00007aa00, 0x0, 0x0)
	/home/runner/go/pkg/mod/github.com/go-gormigrate/gormigrate/v2@v2.0.0/gormigrate.go:376
```

Fixed by converting calls to `Raw(x).Row().Scan(&y)` to `Raw(x).Scan(&y).Error`


### User Case Description

Call Migrator.HasTable when the Posgres DB is stopped.