### PR TITLE
fix postgres.go -> DataTypeOf return pg original type(smallint->int2,integer->int4,bigint->int8)

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -163,11 +163,11 @@ func (dialector Dialector) DataTypeOf(field *schema.Field) string {
 		} else {
 			switch {
 			case size <= 16:
-				return "smallint"
+				return "int2"
 			case size <= 32:
-				return "integer"
+				return "int4"
 			default:
-				return "bigint"
+				return "int8"
 			}
 		}
 	case schema.Float:


### PR DESCRIPTION
… integer->int4,bigint->int8)

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->

in some times. we need create partitiontable. eg
```go
type P struct {
    ID    int64
   IO    uint8  // int2 -> smallint
   BizID uint16 // int4 -> integer
}
```

first, you only need to create table by sql:
```sql
CREATE TABLE IF NOT EXISTS ps (id BIGSERIAL NOT NULL, io smallint, biz_id integer) PARTITION BY LIST(biz_id)
```

second, call AutoMigrate
```go
if err := db.AutoMigrate(&P{}); err != nil {
	println(err)
}
```
 then you found the pg database return datatype is `int2` and `int8`, gorm will try to `alter table alter column` use integer and smallint, but partition column is not allow to alter. the error was:
```
cannot alter column "biz_id" because it is part of the partition key of relation "ps".
```