### PR TITLE
fix timestamptz(0) and fix AlterColumn Trans error(simple set tx = m.DB)

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -246,73 +246,72 @@ func (m Migrator) AlterColumn(value interface{}, field string) error {
 				}
 			}
 
-			return m.DB.Connection(func(tx *gorm.DB) error {
-				fileType := clause.Expr{SQL: m.DataTypeOf(field)}
-				if fieldColumnType.DatabaseTypeName() != fileType.SQL {
-					filedColumnAutoIncrement, _ := fieldColumnType.AutoIncrement()
-					if field.AutoIncrement && filedColumnAutoIncrement { // update
-						serialDatabaseType, _ := getSerialDatabaseType(fileType.SQL)
-						if t, _ := fieldColumnType.ColumnType(); t != serialDatabaseType {
-							if err := m.UpdateSequence(tx, stmt, field, serialDatabaseType); err != nil {
-								return err
-							}
-						}
-					} else if field.AutoIncrement && !filedColumnAutoIncrement { // create
-						serialDatabaseType, _ := getSerialDatabaseType(fileType.SQL)
-						if err := m.CreateSequence(tx, stmt, field, serialDatabaseType); err != nil {
-							return err
-						}
-					} else if !field.AutoIncrement && filedColumnAutoIncrement { // delete
-						if err := m.DeleteSequence(tx, stmt, field, fileType); err != nil {
-							return err
-						}
-					} else {
-						if err := tx.Exec("ALTER TABLE ? ALTER COLUMN ? TYPE ?", m.CurrentTable(stmt), clause.Column{Name: field.DBName}, fileType).Error; err != nil {
+			tx := m.DB
+			fileType := clause.Expr{SQL: m.DataTypeOf(field)}
+			if fieldColumnType.DatabaseTypeName() != fileType.SQL {
+				filedColumnAutoIncrement, _ := fieldColumnType.AutoIncrement()
+				if field.AutoIncrement && filedColumnAutoIncrement { // update
+					serialDatabaseType, _ := getSerialDatabaseType(fileType.SQL)
+					if t, _ := fieldColumnType.ColumnType(); t != serialDatabaseType {
+						if err := m.UpdateSequence(tx, stmt, field, serialDatabaseType); err != nil {
 							return err
 						}
 					}
-				}
-
-				if null, _ := fieldColumnType.Nullable(); null == field.NotNull {
-					if field.NotNull {
-						if err := tx.Exec("ALTER TABLE ? ALTER COLUMN ? SET NOT NULL", m.CurrentTable(stmt), clause.Column{Name: field.DBName}).Error; err != nil {
-							return err
-						}
-					} else {
-						if err := tx.Exec("ALTER TABLE ? ALTER COLUMN ? DROP NOT NULL", m.CurrentTable(stmt), clause.Column{Name: field.DBName}).Error; err != nil {
-							return err
-						}
+				} else if field.AutoIncrement && !filedColumnAutoIncrement { // create
+					serialDatabaseType, _ := getSerialDatabaseType(fileType.SQL)
+					if err := m.CreateSequence(tx, stmt, field, serialDatabaseType); err != nil {
+						return err
 					}
-				}
-
-				if uniq, _ := fieldColumnType.Unique(); uniq != field.Unique {
-					idxName := clause.Column{Name: m.DB.Config.NamingStrategy.IndexName(stmt.Table, field.DBName)}
-					if err := tx.Exec("ALTER TABLE ? ADD CONSTRAINT ? UNIQUE(?)", m.CurrentTable(stmt), idxName, clause.Column{Name: field.DBName}).Error; err != nil {
+				} else if !field.AutoIncrement && filedColumnAutoIncrement { // delete
+					if err := m.DeleteSequence(tx, stmt, field, fileType); err != nil {
+						return err
+					}
+				} else {
+					if err := tx.Exec("ALTER TABLE ? ALTER COLUMN ? TYPE ?", m.CurrentTable(stmt), clause.Column{Name: field.DBName}, fileType).Error; err != nil {
 						return err
 					}
 				}
+			}
 
-				if v, _ := fieldColumnType.DefaultValue(); v != field.DefaultValue {
-					if field.HasDefaultValue && (field.DefaultValueInterface != nil || field.DefaultValue != "") {
-						if field.DefaultValueInterface != nil {
-							defaultStmt := &gorm.Statement{Vars: []interface{}{field.DefaultValueInterface}}
-							m.Dialector.BindVarTo(defaultStmt, defaultStmt, field.DefaultValueInterface)
-							if err := tx.Exec("ALTER TABLE ? ALTER COLUMN ? SET DEFAULT ?", m.CurrentTable(stmt), clause.Column{Name: field.DBName}, clause.Expr{SQL: m.Dialector.Explain(defaultStmt.SQL.String(), field.DefaultValueInterface)}).Error; err != nil {
-								return err
-							}
-						} else if field.DefaultValue != "(-)" {
-							if err := tx.Exec("ALTER TABLE ? ALTER COLUMN ? SET DEFAULT ?", m.CurrentTable(stmt), clause.Column{Name: field.DBName}, clause.Expr{SQL: field.DefaultValue}).Error; err != nil {
-								return err
-							}
-						} else {
-							if err := tx.Exec("ALTER TABLE ? ALTER COLUMN ? DROP DEFAULT", m.CurrentTable(stmt), clause.Column{Name: field.DBName}, clause.Expr{SQL: field.DefaultValue}).Error; err != nil {
-								return err
-							}
+			if null, _ := fieldColumnType.Nullable(); null == field.NotNull {
+				if field.NotNull {
+					if err := tx.Exec("ALTER TABLE ? ALTER COLUMN ? SET NOT NULL", m.CurrentTable(stmt), clause.Column{Name: field.DBName}).Error; err != nil {
+						return err
+					}
+				} else {
+					if err := tx.Exec("ALTER TABLE ? ALTER COLUMN ? DROP NOT NULL", m.CurrentTable(stmt), clause.Column{Name: field.DBName}).Error; err != nil {
+						return err
+					}
+				}
+			}
+
+			if uniq, _ := fieldColumnType.Unique(); !(uniq == field.Unique || uniq == field.UniqueIndex) {
+				idxName := clause.Column{Name: m.DB.Config.NamingStrategy.IndexName(stmt.Table, field.DBName)}
+				if err := tx.Exec("ALTER TABLE ? ADD CONSTRAINT ? UNIQUE(?)", m.CurrentTable(stmt), idxName, clause.Column{Name: field.DBName}).Error; err != nil {
+					return err
+				}
+			}
+
+			if v, _ := fieldColumnType.DefaultValue(); v != field.DefaultValue {
+				if field.HasDefaultValue && (field.DefaultValueInterface != nil || field.DefaultValue != "") {
+					if field.DefaultValueInterface != nil {
+						defaultStmt := &gorm.Statement{Vars: []interface{}{field.DefaultValueInterface}}
+						m.Dialector.BindVarTo(defaultStmt, defaultStmt, field.DefaultValueInterface)
+						if err := tx.Exec("ALTER TABLE ? ALTER COLUMN ? SET DEFAULT ?", m.CurrentTable(stmt), clause.Column{Name: field.DBName}, clause.Expr{SQL: m.Dialector.Explain(defaultStmt.SQL.String(), field.DefaultValueInterface)}).Error; err != nil {
+							return err
+						}
+					} else if field.DefaultValue != "(-)" {
+						if err := tx.Exec("ALTER TABLE ? ALTER COLUMN ? SET DEFAULT ?", m.CurrentTable(stmt), clause.Column{Name: field.DBName}, clause.Expr{SQL: field.DefaultValue}).Error; err != nil {
+							return err
+						}
+					} else {
+						if err := tx.Exec("ALTER TABLE ? ALTER COLUMN ? DROP DEFAULT", m.CurrentTable(stmt), clause.Column{Name: field.DBName}, clause.Expr{SQL: field.DefaultValue}).Error; err != nil {
+							return err
 						}
 					}
 				}
-				return nil
-			})
+			}
+			return nil
 		}
 		return fmt.Errorf("failed to look up field with name: %s", field)
 	})

--- a/postgres.go
+++ b/postgres.go
@@ -186,10 +186,8 @@ func (dialector Dialector) DataTypeOf(field *schema.Field) string {
 		}
 		return "text"
 	case schema.Time:
-		if field.Precision > 0 {
-			return fmt.Sprintf("timestamptz(%d)", field.Precision)
-		}
-		return "timestamptz"
+		// in postgresql, Precision == 0, This means being accurate to the seconds.
+		return fmt.Sprintf("timestamptz(%d)", field.Precision)
 	case schema.Bytes:
 		return "bytea"
 	}


### PR DESCRIPTION

1. fix time.Time type. in postgresql, Precision == 0, This means being accurate to the seconds.
2. fix AlterColumn(Do not attempt to create a new connection in AlterColumn,simple get tx = m.DB)
3, fix unique check

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->

```go
  // 1. in gostgres.go,  line 147
  func (dialector Dialector) DataTypeOf(field *schema.Field) string {
      // ......
       case schema.Time:
	    // in postgresql, Precision == 0, This means being accurate to the seconds.
	    return fmt.Sprintf("timestamptz(%d)", field.Precision)
      // ......
  }

  // 2. in migrator.go, line 236
  func (m Migrator) AlterColumn(value interface{}, field string) error {
        // ......
       tx:=m.DB
       // return m.DB.Connection(func(tx *gorm.DB) error {
             // ......
             // line 289
             if uniq, _ := fieldColumnType.Unique(); !(uniq == field.Unique || uniq == field.UniqueIndex) {
                 // ......
             }
       //})
        // ......
  }
```