### PR TITLE
fix pg datatype

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/stdlib"
 	"gorm.io/gorm"
 	"gorm.io/gorm/callbacks"
@@ -165,11 +164,11 @@ func (dialector Dialector) DataTypeOf(field *schema.Field) string {
 		} else {
 			switch {
 			case size <= 16:
-				return "smallint"
+				return "int2"
 			case size <= 32:
-				return "integer"
+				return "int4"
 			default:
-				return "bigint"
+				return "int8"
 			}
 		}
 	case schema.Float:
@@ -186,10 +185,8 @@ func (dialector Dialector) DataTypeOf(field *schema.Field) string {
 		}
 		return "text"
 	case schema.Time:
-		if field.Precision > 0 {
-			return fmt.Sprintf("timestamptz(%d)", field.Precision)
-		}
-		return "timestamptz"
+		// in postgresql, Precision == 0, This means being accurate to the seconds.
+		return fmt.Sprintf("timestamptz(%d)", field.Precision)
 	case schema.Bytes:
 		return "bytea"
 	}
@@ -210,11 +207,11 @@ func (dialectopr Dialector) RollbackTo(tx *gorm.DB, name string) error {
 func getSerialDatabaseType(s string) (dbType string, ok bool) {
 	switch s {
 	case "smallserial":
-		return "smallint", true
+		return "int2", true
 	case "serial":
-		return "integer", true
+		return "int4", true
 	case "bigserial":
-		return "bigint", true
+		return "int8", true
 	default:
 		return "", false
 	}


### PR DESCRIPTION
* 1. because select schema from db, return int2,int4,int8. but code name is smallint,integer,bigint. it will cause alter column.
 a. smallint -> int2
 b. integer -> int4
 c. bigint -> int8
2. in postgresql, Precision == 0, This means being accurate to the seconds.
   timestamptz set size to 0, because parse field get size is 0, not 64, it will cause alter column.

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [] Non breaking API changes
- [] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
