### PR TITLE
[CockroachDB] Fixing how it handle fields DEFAULT values and column types

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -424,6 +424,9 @@ func (m Migrator) ColumnTypes(value interface{}) (columnTypes []gorm.ColumnType,
 
 			if column.DefaultValueValue.Valid {
 				column.DefaultValueValue.String = regexp.MustCompile(`'(.*)'::[\w\s]+$`).ReplaceAllString(column.DefaultValueValue.String, "$1")
+				column.DefaultValueValue.String = regexp.MustCompile(`'(.*)'::[\w]+$`).ReplaceAllString(column.DefaultValueValue.String, "$1")
+				// cockroachdb, removing :::type
+				column.DefaultValueValue.String = regexp.MustCompile(`(.*):::[\w]+$`).ReplaceAllString(column.DefaultValueValue.String, "$1")
 			}
 
 			if datetimePrecision.Valid {

--- a/migrator.go
+++ b/migrator.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/jackc/pgx/v5"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/migrator"
@@ -438,10 +437,7 @@ func (m Migrator) ColumnTypes(value interface{}) (columnTypes []gorm.ColumnType,
 			}
 
 			if column.DefaultValueValue.Valid {
-				column.DefaultValueValue.String = regexp.MustCompile(`'(.*)'::[\w\s]+$`).ReplaceAllString(column.DefaultValueValue.String, "$1")
-				column.DefaultValueValue.String = regexp.MustCompile(`'(.*)'::[\w]+$`).ReplaceAllString(column.DefaultValueValue.String, "$1")
-				// cockroachdb, removing :::type
-				column.DefaultValueValue.String = regexp.MustCompile(`(.*):::[\w]+$`).ReplaceAllString(column.DefaultValueValue.String, "$1")
+				column.DefaultValueValue.String = regexp.MustCompile(`'?(.*)\b'?:+[\w\s]+$`).ReplaceAllString(column.DefaultValueValue.String, "$1")
 			}
 
 			if datetimePrecision.Valid {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

Currently, CockroachDB returns `:::int8` together with their default values. We have a regex to remove it, that solves issues with PostgreSQL values, but it doesn't solve cockroachdb ones. So, I'm adding another regex to fix it.
Also, column field types has aliases, and the migrator check them to decide if we need to ALTER a column or not. But the driver is not checking it, so, I'm adding this alias check as well.

### User Case Description

You can test this this model:
```
type Example struct {
	Code   int    `gorm:"default:0"`
}
```
It would trigger the ALTER COLUMN every time since `int` returns `int8` and wasn't considering the alias to `bigint`. Also, it would have issues with the `default:0`, since it would check against `0:::int8` and `0`.