### PR TITLE
Disable add existing constraint

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -319,7 +319,7 @@ func (m Migrator) AlterColumn(value interface{}, field string) error {
 				}
 			}
 
-			if uniq, _ := fieldColumnType.Unique(); uniq != field.Unique {
+			if uniq, _ := fieldColumnType.Unique(); !uniq && field.Unique {
 				idxName := clause.Column{Name: m.DB.Config.NamingStrategy.IndexName(stmt.Table, field.DBName)}
 				if err := m.DB.Exec("ALTER TABLE ? ADD CONSTRAINT ? UNIQUE(?)", m.CurrentTable(stmt), idxName, clause.Column{Name: field.DBName}).Error; err != nil {
 					return err


### PR DESCRIPTION
Disabling add constraint when constraint doesn't present in model but present in the database.

### User Case Description

For example run automigrate for this Model


```
type Values struct {
	Name  string `gorm:"unique"`
	MyVal  bool   
}

  ....

db.Migrator().AutoMigrate(&Values{})

```


Try again after removing constraint "unique" from Name field

```
type Values struct {
	Name  string 
	MyVal  bool   
}

  ....

db.Migrator().AutoMigrate(&Values{})
```

Got errors messages:
```
ERROR: relation "idx_valuses_name" already exists (SQLSTATE 42P07)
```



