### PR TITLE
fix : fail to alter column from smallint to boolean

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -320,7 +320,7 @@ func (m Migrator) AlterColumn(value interface{}, field string) error {
 						sqlUsing = "USING ?::INT::?"
 
 					}
-					if err := m.DB.Exec("ALTER TABLE ? ALTER COLUMN ? TYPE ?"+sqlUsing,
+					if err := m.DB.Exec("ALTER TABLE ? ALTER COLUMN ? TYPE ? "+sqlUsing,
 						m.CurrentTable(stmt), clause.Column{Name: field.DBName}, fileType, clause.Column{Name: field.DBName}, fileType).Error; err != nil {
 						return err
 					}

--- a/migrator.go
+++ b/migrator.go
@@ -315,7 +315,7 @@ func (m Migrator) AlterColumn(value interface{}, field string) error {
 						return err
 					}
 				} else {
-					if err := m.DB.Exec("ALTER TABLE ? ALTER COLUMN ? TYPE ? USING "+m.genUsingExpression(fileType.SQL, fieldColumnType.DatabaseTypeName()),
+					if err := m.DB.Exec("ALTER TABLE ? ALTER COLUMN ? TYPE ?"+m.genUsingExpression(fileType.SQL, fieldColumnType.DatabaseTypeName()),
 						m.CurrentTable(stmt), clause.Column{Name: field.DBName}, fileType, clause.Column{Name: field.DBName}, fileType).Error; err != nil {
 						return err
 					}
@@ -379,10 +379,10 @@ func (m Migrator) genUsingExpression(targetType, sourceType string) string {
 	if targetType == "boolean" {
 		switch sourceType {
 		case "int2", "int8", "numeric":
-			return "?::INT::?"
+			return " USING ?::INT::?"
 		}
 	}
-	return "?::?"
+	return " USING ?::?"
 }
 
 func (m Migrator) HasConstraint(value interface{}, name string) bool {

--- a/migrator.go
+++ b/migrator.go
@@ -315,7 +315,12 @@ func (m Migrator) AlterColumn(value interface{}, field string) error {
 						return err
 					}
 				} else {
-					if err := m.DB.Exec("ALTER TABLE ? ALTER COLUMN ? TYPE ? USING ?::?",
+					sqlUsing := "USING ?::?"
+					if fileType.SQL == "boolean" {
+						sqlUsing = "USING ?::INT::?"
+
+					}
+					if err := m.DB.Exec("ALTER TABLE ? ALTER COLUMN ? TYPE ?"+sqlUsing,
 						m.CurrentTable(stmt), clause.Column{Name: field.DBName}, fileType, clause.Column{Name: field.DBName}, fileType).Error; err != nil {
 						return err
 					}

--- a/migrator.go
+++ b/migrator.go
@@ -316,7 +316,7 @@ func (m Migrator) AlterColumn(value interface{}, field string) error {
 					}
 				} else if fileType.SQL == "boolean" {
 					trueValues := []string{"1", "TRUE", "True", "true", "T", "t"}
-					if err := m.DB.Exec("ALTER TABLE ? ALTER COLUMN ? TYPE ? USING CASE WHEN ?::VARCHAR(4) IN (?) THEN true ELSE false END",
+					if err := m.DB.Exec("ALTER TABLE ? ALTER COLUMN ? TYPE ? USING CASE WHEN ?::VARCHAR(5) IN (?) THEN true ELSE false END",
 						m.CurrentTable(stmt), clause.Column{Name: field.DBName}, fileType, clause.Column{Name: field.DBName}, trueValues).Error; err != nil {
 						return err
 					}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Fix `USING ?::?` sql for boolean field on `AlterColumn` func

Without this, it will report error as I described in the issue https://github.com/go-gorm/postgres/issues/164

### User Case Description

<!-- Your use case -->

If we want to change column from smallint to boolean, it will report error like below:

```bash
2023/02/28 14:03:35 /home/user/go/pkg/mod/gorm.io/driver/postgres@v1.4.8/migrator.go:318 ERROR: cannot cast type smallint to boolean (SQLSTATE 42846)
[0.374ms] [rows:0] ALTER TABLE "column_structs" ALTER COLUMN "is_active" TYPE boolean USING "is_active"::boolean
```

We only need to fix sql become `USING xxx::int::boolean` for boolean field in func `AlterColumn` in `postgres@v1.4.8/migrator.go`