### PR TITLE
feat: support for traslating error for pg driver

### DIFF
--- a/error_translator.go
+++ b/error_translator.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"encoding/json"
 	"github.com/jackc/pgx/v5/pgconn"
 	"gorm.io/gorm"
 )
@@ -9,11 +10,34 @@ var errCodes = map[string]string{
 	"uniqueConstraint": "23505",
 }
 
+type ErrMessage struct {
+	Code     string `json:"Code"`
+	Severity string `json:"Severity"`
+	Message  string `json:"Message"`
+}
+
+// Translate it will translate the error to native gorm errors.
+// Since currently gorm supporting both pgx and pg drivers, only checking for pgx PgError types is not enough for translating errors, so we have additional error json marshal fallback.
 func (dialector Dialector) Translate(err error) error {
 	if pgErr, ok := err.(*pgconn.PgError); ok {
 		if pgErr.Code == errCodes["uniqueConstraint"] {
 			return gorm.ErrDuplicatedKey
 		}
+	}
+
+	parsedErr, marshalErr := json.Marshal(err)
+	if marshalErr != nil {
+		return err
+	}
+
+	var errMsg ErrMessage
+	unmarshalErr := json.Unmarshal(parsedErr, &errMsg)
+	if unmarshalErr != nil {
+		return err
+	}
+
+	if errMsg.Code == errCodes["uniqueConstraint"] {
+		return gorm.ErrDuplicatedKey
 	}
 
 	return err

--- a/error_translator.go
+++ b/error_translator.go
@@ -23,6 +23,7 @@ func (dialector Dialector) Translate(err error) error {
 		if pgErr.Code == errCodes["uniqueConstraint"] {
 			return gorm.ErrDuplicatedKey
 		}
+		return err
 	}
 
 	parsedErr, marshalErr := json.Marshal(err)
@@ -39,6 +40,5 @@ func (dialector Dialector) Translate(err error) error {
 	if errMsg.Code == errCodes["uniqueConstraint"] {
 		return gorm.ErrDuplicatedKey
 	}
-
 	return err
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Currently the translating error feature is only working for pgx driver but since Gorm is supporting both pg & pgx drivers for Postgres, this PR will add support for pg driver as well.

Here is the reported issue: https://github.com/go-gorm/gorm/issues/6299
