### PR TITLE
Add posibility to define connection hooks

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -27,6 +27,7 @@ type Config struct {
 	PreferSimpleProtocol bool
 	WithoutReturning     bool
 	Conn                 gorm.ConnPool
+	OptionOpenDB         []stdlib.OptionOpenDB
 }
 
 func Open(dsn string) gorm.Dialector {
@@ -75,7 +76,7 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 		if len(result) > 2 {
 			config.RuntimeParams["timezone"] = result[2]
 		}
-		db.ConnPool = stdlib.OpenDB(*config)
+		db.ConnPool = stdlib.OpenDB(*config, dialector.OptionOpenDB...)
 	}
 	return
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ X] Do only one thing
- [ X] Non breaking API changes
- [ ...] Tested

### What did this pull request do?

It gives the possibility to define `BeforeConnect` and `AfterConnect` on stdlib connection.

### User Case Description

Generate an IAM Auth password for RDS just before a new connection is opened. Tokens are valid for only 15 minutes, so after w while they have to be regenerated, for the pool to be able to open new connections
