### PR TITLE
Add timestamp with timezone alias

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -35,14 +35,16 @@ where
 `
 
 var typeAliasMap = map[string][]string{
-	"int2":     {"smallint"},
-	"int4":     {"integer"},
-	"int8":     {"bigint"},
-	"smallint": {"int2"},
-	"integer":  {"int4"},
-	"bigint":   {"int8"},
-	"decimal":  {"numeric"},
-	"numeric":  {"decimal"},
+	"int2":                     {"smallint"},
+	"int4":                     {"integer"},
+	"int8":                     {"bigint"},
+	"smallint":                 {"int2"},
+	"integer":                  {"int4"},
+	"bigint":                   {"int8"},
+	"decimal":                  {"numeric"},
+	"numeric":                  {"decimal"},
+	"timestamptz":              {"timestamp with time zone"},
+	"timestamp with time zone": {"timestamptz"},
 }
 
 type Migrator struct {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?
Adds proper work for "time stamp with time zone" type
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
I've faced extra "ALTER TABLE..." requests on every app start with Gorm auto-migrate. Investigated that Gorm can't recognize timestamp with timezone type because it comes as 'timestamptz' from postgres
