### PR TITLE
Fix regex for empty string as default for varchar and text types

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -475,7 +475,9 @@ func (m Migrator) ColumnTypes(value interface{}) (columnTypes []gorm.ColumnType,
 			}
 
 			if column.DefaultValueValue.Valid {
-				column.DefaultValueValue.String = regexp.MustCompile(`'?(.*)\b'?:+[\w\s]+$`).ReplaceAllString(column.DefaultValueValue.String, "$1")
+				column.DefaultValueValue.String = regexp.MustCompile(`'(.*)'::[\w\s]+$`).ReplaceAllString(column.DefaultValueValue.String, "$1")
+				// cockroachdb, removing :::type
+				column.DefaultValueValue.String = regexp.MustCompile(`(.*):::[\w\s]+$`).ReplaceAllString(column.DefaultValueValue.String, "$1")			}
 			}
 
 			if datetimePrecision.Valid {

--- a/migrator.go
+++ b/migrator.go
@@ -477,7 +477,7 @@ func (m Migrator) ColumnTypes(value interface{}) (columnTypes []gorm.ColumnType,
 			if column.DefaultValueValue.Valid {
 				column.DefaultValueValue.String = regexp.MustCompile(`'(.*)'::[\w\s]+$`).ReplaceAllString(column.DefaultValueValue.String, "$1")
 				// cockroachdb, removing :::type
-				column.DefaultValueValue.String = regexp.MustCompile(`(.*):::[\w\s]+$`).ReplaceAllString(column.DefaultValueValue.String, "$1")			}
+				column.DefaultValueValue.String = regexp.MustCompile(`(.*):::[\w\s]+$`).ReplaceAllString(column.DefaultValueValue.String, "$1")
 			}
 
 			if datetimePrecision.Valid {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
Fix regex to properly cut default value for default empty string and default whitespace

### User Case Description

I've faced extra "ALTER TABLE..." requests on every app start with Gorm auto-migrate. Investigated that Gorm doesn't cut properly "default" value, if it is empty string or whitespace. Returned to case with 2 separate regexes that was first added in https://github.com/go-gorm/postgres/pull/143#discussion_r1056736772
