### PR TITLE
fix text default value produces "'::text'" as value

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -477,7 +477,7 @@ func (m Migrator) ColumnTypes(value interface{}) (columnTypes []gorm.ColumnType,
 			}
 
 			if column.DefaultValueValue.Valid {
-				column.DefaultValueValue.String = regexp.MustCompile(`'?(.*)\b?'?::[\w ]+$`).ReplaceAllString(column.DefaultValueValue.String, "$2")
+				column.DefaultValueValue.String = regexp.MustCompile(`'?(.*\b|)'?:+[\w\s]+$`).ReplaceAllString(column.DefaultValueValue.String, "$1")
 			}
 
 			if datetimePrecision.Valid {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [ ] Non breaking API changes
- [x] Tested

### What did this pull request do?
Fixing incorrect default value in auto generated models.

### User Case Description
If DB column definition has `column name text default value ''` then the generated model will have the Go tag: `default:"''::text"` and value `''::text` will be written to DB column as default value.