### PR TITLE
allow ignoring escape and quoting

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -24,6 +24,7 @@ type Dialector struct {
 type Config struct {
 	DriverName           string
 	DSN                  string
+	WithoutQuotingCheck  bool
 	PreferSimpleProtocol bool
 	WithoutReturning     bool
 	Conn                 gorm.ConnPool
@@ -98,6 +99,11 @@ func (dialector Dialector) BindVarTo(writer clause.Writer, stmt *gorm.Statement,
 }
 
 func (dialector Dialector) QuoteTo(writer clause.Writer, str string) {
+	if dialector.WithoutQuotingCheck {
+		writer.WriteString(str)
+		return
+	}
+
 	var (
 		underQuoted, selfQuoted bool
 		continuousBacktick      int8


### PR DESCRIPTION

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR allows the developer to take responsability of column names and table names correctness,
by correctness I mean no special characters and no postgres reserved keywords.

Benefits :

- less run time for checking each byte for an invalid character,

- more flexibility when the developer wants to ignore casing in his database columns and table names

### User Case Description

In my case, the double quotes around table names and columns, make my query case sensitive to the casing of table names
and columns.

In my case, performance is crucial, avoiding going over bytes in the query, could be significant on the long run

