### PR TITLE
override identifier length for postgres

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -30,6 +30,11 @@ type Config struct {
 	Conn                 gorm.ConnPool
 }
 
+var (
+	timeZoneMatcher         = regexp.MustCompile("(time_zone|TimeZone)=(.*?)($|&| )")
+	defaultIdentifierLength = 63 //maximum identifier length for postgres
+)
+
 func Open(dsn string) gorm.Dialector {
 	return &Dialector{&Config{DSN: dsn}}
 }
@@ -42,7 +47,20 @@ func (dialector Dialector) Name() string {
 	return "postgres"
 }
 
-var timeZoneMatcher = regexp.MustCompile("(time_zone|TimeZone)=(.*?)($|&| )")
+func (dialector Dialector) Apply(config *gorm.Config) error {
+	var namingStartegy *schema.NamingStrategy
+	switch v := config.NamingStrategy.(type) {
+	case *schema.NamingStrategy:
+		namingStartegy = v
+	case schema.NamingStrategy:
+		namingStartegy = &v
+	case nil:
+		namingStartegy = &schema.NamingStrategy{}
+	}
+	namingStartegy.IdentifierMaxLength = defaultIdentifierLength
+	config.NamingStrategy = namingStartegy
+	return nil
+}
 
 func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 	callbackConfig := &callbacks.Config{

--- a/postgres.go
+++ b/postgres.go
@@ -57,7 +57,9 @@ func (dialector Dialector) Apply(config *gorm.Config) error {
 	case nil:
 		namingStartegy = &schema.NamingStrategy{}
 	}
-	namingStartegy.IdentifierMaxLength = defaultIdentifierLength
+	if namingStartegy.IdentifierMaxLength <= 0 {
+		namingStartegy.IdentifierMaxLength = defaultIdentifierLength
+	}
 	config.NamingStrategy = namingStartegy
 	return nil
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR addresses [issue-191](https://github.com/go-gorm/postgres/issues/191). It overrides gorm's default maximum identifier length by Postgres maximum identifier length of 63.
provide a general description of the code changes in your pull request

### User Case Description
It sets default max identifier length to that of Postgres, which is 63, without changing anyother naming strategy, if defined by user.