### PR TITLE
Fix ci , field named "code2"  add unique. 

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -120,13 +120,7 @@ func (dialector Dialector) BindVarTo(writer clause.Writer, stmt *gorm.Statement,
 optionLoop:
 	for varLen > index {
 		switch stmt.Vars[index].(type) {
-		case pgx.QueryResultFormats:
-			index++
-		case pgx.QueryResultFormatsByOID:
-			index++
 		case pgx.QueryExecMode:
-			index++
-		case pgx.QueryRewriter:
 			index++
 		default:
 			break optionLoop

--- a/postgres.go
+++ b/postgres.go
@@ -118,7 +118,7 @@ func (dialector Dialector) BindVarTo(writer clause.Writer, stmt *gorm.Statement,
 	index := 0
 	varLen := len(stmt.Vars)
 	if varLen > 0 {
-		switch stmt.Vars[index].(type) {
+		switch stmt.Vars[0].(type) {
 		case pgx.QueryExecMode:
 			index++
 		}

--- a/postgres.go
+++ b/postgres.go
@@ -117,13 +117,10 @@ func (dialector Dialector) BindVarTo(writer clause.Writer, stmt *gorm.Statement,
 	writer.WriteByte('$')
 	index := 0
 	varLen := len(stmt.Vars)
-optionLoop:
-	for varLen > index {
+	if varLen > 0 {
 		switch stmt.Vars[index].(type) {
 		case pgx.QueryExecMode:
 			index++
-		default:
-			break optionLoop
 		}
 	}
 	writer.WriteString(strconv.Itoa(varLen - index))

--- a/postgres.go
+++ b/postgres.go
@@ -115,23 +115,24 @@ func (dialector Dialector) DefaultValueOf(field *schema.Field) clause.Expression
 
 func (dialector Dialector) BindVarTo(writer clause.Writer, stmt *gorm.Statement, v interface{}) {
 	writer.WriteByte('$')
+	index := 0
 	varLen := len(stmt.Vars)
 optionLoop:
-	for len(stmt.Vars) > 0 {
-		switch stmt.Vars[0].(type) {
+	for varLen > index {
+		switch stmt.Vars[index].(type) {
 		case pgx.QueryResultFormats:
-			varLen--
+			index++
 		case pgx.QueryResultFormatsByOID:
-			varLen--
+			index++
 		case pgx.QueryExecMode:
-			varLen--
+			index++
 		case pgx.QueryRewriter:
-			varLen--
+			index++
 		default:
 			break optionLoop
 		}
 	}
-	writer.WriteString(strconv.Itoa(varLen))
+	writer.WriteString(strconv.Itoa(varLen - index))
 }
 
 func (dialector Dialector) QuoteTo(writer clause.Writer, str string) {

--- a/postgres.go
+++ b/postgres.go
@@ -115,30 +115,23 @@ func (dialector Dialector) DefaultValueOf(field *schema.Field) clause.Expression
 
 func (dialector Dialector) BindVarTo(writer clause.Writer, stmt *gorm.Statement, v interface{}) {
 	writer.WriteByte('$')
-	var tmpVars []interface{}
+	varLen := len(stmt.Vars)
 optionLoop:
 	for len(stmt.Vars) > 0 {
-		switch arg := stmt.Vars[0].(type) {
+		switch stmt.Vars[0].(type) {
 		case pgx.QueryResultFormats:
-			stmt.Vars = stmt.Vars[1:]
-			tmpVars = append(tmpVars, arg)
+			varLen--
 		case pgx.QueryResultFormatsByOID:
-			stmt.Vars = stmt.Vars[1:]
-			tmpVars = append(tmpVars, arg)
+			varLen--
 		case pgx.QueryExecMode:
-			stmt.Vars = stmt.Vars[1:]
-			tmpVars = append(tmpVars, arg)
+			varLen--
 		case pgx.QueryRewriter:
-			stmt.Vars = stmt.Vars[1:]
-			tmpVars = append(tmpVars, arg)
+			varLen--
 		default:
 			break optionLoop
 		}
 	}
-	writer.WriteString(strconv.Itoa(len(stmt.Vars)))
-	if len(tmpVars) > 0 {
-		stmt.Vars = append(tmpVars, stmt.Vars...)
-	}
+	writer.WriteString(strconv.Itoa(varLen))
 }
 
 func (dialector Dialector) QuoteTo(writer clause.Writer, str string) {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [ ] Non breaking API changes
- [ ] Tested

### What did this pull request do?
gorm test of migrate_test.go:613: column code2 unique should be correct

### User Case Description

column code2 was not unique before ,and then if we  migrate a object with column code2  unique  , Migrater of postgre can't alter the table add the CONSTRAINT

