### PR TITLE
Add "boolean" as an alias for "bool"

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -48,6 +48,7 @@ var typeAliasMap = map[string][]string{
 	"numeric":                  {"decimal"},
 	"timestamptz":              {"timestamp with time zone"},
 	"timestamp with time zone": {"timestamptz"},
+	"bool":                     {"boolean"},
 }
 
 type Migrator struct {

--- a/migrator.go
+++ b/migrator.go
@@ -49,6 +49,7 @@ var typeAliasMap = map[string][]string{
 	"timestamptz":              {"timestamp with time zone"},
 	"timestamp with time zone": {"timestamptz"},
 	"bool":                     {"boolean"},
+	"boolean":                  {"bool"},
 }
 
 type Migrator struct {


### PR DESCRIPTION
Postgres returns `udt_type` "bool" for columns of type "boolean"

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### User Case Description

Otherwise migrator detects a type mismatch and attempts to needlessly change the column type. This is normally not an issue. However, it fails when there's a view that depends on that column:

`
ALTER TABLE "records" ALTER COLUMN "deleted" TYPE boolean USING "deleted"::boolean: ERROR: cannot alter type of a column used by a view or rule (SQLSTATE 0A000)
`

This in turn fails the whole auto-migration.