### PR TITLE
Fix same type comparing

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -312,7 +312,7 @@ func (m Migrator) AlterColumn(value interface{}, field string) error {
 				fileType := clause.Expr{SQL: m.DataTypeOf(field)}
 				// check for typeName and SQL name
 				isSameType := true
-				if strings.ToUpper(fieldColumnType.DatabaseTypeName()) != fileType.SQL {
+				if strings.EqualFold(fieldColumnType.DatabaseTypeName(), fileType.SQL) {
 					isSameType = false
 					// if different, also check for aliases
 					aliases := m.GetTypeAliases(fieldColumnType.DatabaseTypeName())

--- a/migrator.go
+++ b/migrator.go
@@ -312,7 +312,7 @@ func (m Migrator) AlterColumn(value interface{}, field string) error {
 				fileType := clause.Expr{SQL: m.DataTypeOf(field)}
 				// check for typeName and SQL name
 				isSameType := true
-				if fieldColumnType.DatabaseTypeName() != fileType.SQL {
+				if strings.ToUpper(fieldColumnType.DatabaseTypeName()) != fileType.SQL {
 					isSameType = false
 					// if different, also check for aliases
 					aliases := m.GetTypeAliases(fieldColumnType.DatabaseTypeName())


### PR DESCRIPTION
`fieldColumnType.DatabaseTypeName()` returns non capitalized string, while `fileType.SQL` returns capitalized string. This commit aims to fix this and avoid detecting a type change when the type did not change.

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ x ] Do only one thing
- [ x ] Non breaking API changes
- [ x ] Tested

### What did this pull request do?

Fix same type comparing when running auto-migrate

### User Case Description

When running auto migrate, we detected we ended up attempting to execute the statement.

```
ALTER TABLE "myTable" ALTER COLUMN "myColumn" TYPE JSONB USING "myColumn"::JSONB
```

This resulted in an error since our database (CockroachDB) does not allow type alter statements on JSONB columns.

After reviewing the code and debugging, I noticed that this behaviour was due to this comparison.  
`fieldColumnType.DatabaseTypeName()` returns non capitalised string, while `fileType.SQL` returns capitalised string.  
After using `strings.ToUpper` on `fieldColumnType.DatabaseTypeName()` before comparing it to `fileType.SQL`, this type change is no longer detected and auto-migrate succeeds.

This PR aims to fix this and avoid detecting a type change when the type did not change.