### PR TITLE
Add missing postgres type aliases

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -38,6 +38,7 @@ WHERE
 `
 
 var typeAliasMap = map[string][]string{
+	"int":                      {"integer"},
 	"int2":                     {"smallint"},
 	"int4":                     {"integer"},
 	"int8":                     {"bigint"},
@@ -50,6 +51,15 @@ var typeAliasMap = map[string][]string{
 	"timestamp with time zone": {"timestamptz"},
 	"bool":                     {"boolean"},
 	"boolean":                  {"bool"},
+	"serial2":                  {"smallserial"},
+	"serial4":                  {"serial"},
+	"serial8":                  {"bigserial"},
+	"varbit":                   {"bit varying"},
+	"char":                     {"character"},
+	"varchar":                  {"character varying"},
+	"float4":                   {"real"},
+	"float8":                   {"double precision"},
+	"timetz":                   {"time with time zone"},
 }
 
 type Migrator struct {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

A bunch of Postgres-type aliases are missing in the migrator. AutoMigrate performs an `ALTER COLUMN` even though the column already has the specified data type.

This PR adds the missing aliases, ensuring that the migrator doesn't execute the `ALTER COLUMN` statement, when the given column is already migrated.

The complete list of aliases is in Table 8.1 in the Postgres documentation [here](https://www.postgresql.org/docs/current/datatype.html).

### User Case Description

Adding these aliases ensures that ALTER COLUMN isn't performed when invoking AutoMigrate on a table, where the columns used one of the following types:
* integer
* smallserial
* serial
* bigserial
* bit varying
* character
* character varying
* real
* double precision
* time with time zone
