### PR TITLE
feat: support pgx open db options

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -28,6 +28,7 @@ type Config struct {
 	PreferSimpleProtocol bool
 	WithoutReturning     bool
 	Conn                 gorm.ConnPool
+	OpenOptions          []stdlib.OptionOpenDB
 }
 
 var (
@@ -102,7 +103,7 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 		if len(result) > 2 {
 			config.RuntimeParams["timezone"] = result[2]
 		}
-		db.ConnPool = stdlib.OpenDB(*config)
+		db.ConnPool = stdlib.OpenDB(*config, dialector.OpenOptions...)
 	}
 	return
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Enable the hooks which are supported by pgx, such as `BeforeConnect`, `AfterConnect`.
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

```go
dialector := postgres.New(postgres.Config{
    DSN: "host=localhost user=postgres password=1 dbname=postgres port=5432 sslmode=disable",
    OpenOptions: []stdlib.OptionOpenDB{
        stdlib.OptionBeforeConnect(func(ctx context.Context, cfg *pgx.ConnConfig) error {
            fmt.Println("before connect")
            // do anything with the actual pgx connection config
	    return nil
        }),
    },
})

db, err := gorm.Open(dialector)
```
<!-- Your use case -->
