### PR TITLE
fix: create index failed without err

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -146,7 +146,14 @@ func (m Migrator) CreateIndex(value interface{}, name string) error {
 					createIndexSQL += " WHERE " + idx.Where
 				}
 
-				return m.DB.Exec(createIndexSQL, values...).Error
+				err := m.DB.Exec(createIndexSQL, values...).Error
+				if err != nil {
+					return err
+				}
+
+				if !m.HasIndex(value, name) {
+					return fmt.Errorf("failed to create index with name %v", name)
+				}
 			}
 		}
 


### PR DESCRIPTION

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Check index exists after create index. If not exists, return the err.

We run into this case, because we use the same index name for difference table, and the migration executed successfuly. But when  use do some request, we got a err  `ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification (SQLSTATE 42P10` becase we must make sure the index exists.