### PR TITLE
Respect index option param.

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -142,6 +142,10 @@ func (m Migrator) CreateIndex(value interface{}, name string) error {
 					createIndexSQL += " ?"
 				}
 
+				if idx.Option != "" {
+					createIndexSQL += " " + idx.Option
+				}
+
 				if idx.Where != "" {
 					createIndexSQL += " WHERE " + idx.Where
 				}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X ] Do only one thing
- [ X] Non breaking API changes
- [ X] Tested

### What did this pull request do?

When creating indexes, the option argument is taken into account.

### User Case Description
When creating indexes, users might need greater control over the resulting DDL statement. For example, users need a way to specify "NULLS [ NOT ] DISTINCT" SQL option when working with Postgres as described here:  https://www.postgresql.org/docs/current/sql-createindex.html
Despite documentation stating that `option` param is supported: https://gorm.io/docs/indexes.html, Postgres Mirgator implementation does not use it. Example of use opened issue that will be closed by this PR: https://github.com/go-gorm/gorm/issues/6085

