### PR TITLE
fix concurrent index creation

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -3,10 +3,10 @@ package postgres
 import (
 	"database/sql"
 	"fmt"
+	"github.com/jackc/pgx/v5"
 	"regexp"
 	"strings"
 
-	"github.com/jackc/pgx/v5"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/migrator"
@@ -142,7 +142,7 @@ func (m Migrator) CreateIndex(value interface{}, name string) error {
 					createIndexSQL += " ?"
 				}
 
-				if idx.Option != "" {
+				if idx.Option != "" && strings.TrimSpace(strings.ToUpper(idx.Option)) != "CONCURRENTLY" {
 					createIndexSQL += " " + idx.Option
 				}
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

This resolves issue #293.  The issue was a prior PR to allow for other options blindly applied the options at the end of the SQL statement.  However, `concurrently` does not go at the end of the SQL statement.  Thus #288 broke the usage of concurrently.  Used the playground pointing to this change to verify that the fix works without breaking the issue "fixed" in #288.  

The playground verification https://github.com/go-gorm/playground/pull/779.
 
### User Case Description

<!-- Your use case -->
My case is simple.  I want to create an index concurrently as the documents state.  The documents clearly state that concurrently is an OPTION.  https://gorm.io/docs/indexes.html.  