### PR TITLE
Handle postgres array

### DIFF
--- a/array_handler.go
+++ b/array_handler.go
@@ -1,0 +1,261 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+
+	"gorm.io/gorm/schema"
+)
+
+type PostgresArrayHandler struct{}
+
+type arrayScanner struct {
+	fieldType reflect.Type
+	value     interface{}
+}
+
+func (s *arrayScanner) Scan(src interface{}) error {
+	if src == nil {
+		s.value = reflect.MakeSlice(s.fieldType.Elem(), 0, 0).Interface()
+		return nil
+	}
+
+	switch v := src.(type) {
+	case string:
+		// Remove the curly braces
+		str := strings.Trim(v, "{}")
+
+		// Handle empty array
+		if str == "" {
+			s.value = reflect.MakeSlice(s.fieldType.Elem(), 0, 0).Interface()
+			return nil
+		}
+
+		// Split the string into elements
+		elements := strings.Split(str, ",")
+
+		// Create a new slice with the correct type
+		slice := reflect.MakeSlice(s.fieldType.Elem(), len(elements), len(elements))
+
+		// Convert each element to the correct type
+		for i, elem := range elements {
+			elem = strings.Trim(elem, "\"") // Remove quotes if present
+			switch s.fieldType.Elem().Elem().Kind() {
+			case reflect.String:
+				slice.Index(i).SetString(elem)
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				if val, err := strconv.ParseInt(elem, 10, 64); err == nil {
+					slice.Index(i).SetInt(val)
+				}
+			case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+				if val, err := strconv.ParseUint(elem, 10, 64); err == nil {
+					slice.Index(i).SetUint(val)
+				}
+			case reflect.Float32:
+				if val, err := strconv.ParseFloat(elem, 32); err == nil {
+					slice.Index(i).SetFloat(float64(val))
+				}
+			case reflect.Float64:
+				if val, err := strconv.ParseFloat(elem, 64); err == nil {
+					slice.Index(i).SetFloat(val)
+				}
+			case reflect.Bool:
+				if val, err := strconv.ParseBool(elem); err == nil {
+					slice.Index(i).SetBool(val)
+				}
+			}
+		}
+		s.value = slice.Interface()
+		return nil
+	}
+	return fmt.Errorf("unsupported Scan, storing driver.Value type %T into type %s", src, s.fieldType)
+}
+
+func (s *arrayScanner) Value() (driver.Value, error) {
+	if s.value == nil {
+		return nil, nil
+	}
+	return s.value, nil
+}
+
+func (h *PostgresArrayHandler) HandleArray(field *schema.Field) error {
+	oldValueOf := field.ValueOf
+	field.ValueOf = func(ctx context.Context, v reflect.Value) (interface{}, bool) {
+		value, zero := oldValueOf(ctx, v)
+		if zero {
+			return value, zero
+		}
+
+		return h.convertArrayToPostgres(value)
+	}
+
+	// Mark the field as implementing Scanner interface
+	field.FieldType = reflect.PtrTo(field.FieldType)
+
+	oldSet := field.Set
+	field.Set = func(ctx context.Context, value reflect.Value, v interface{}) error {
+		return h.handleArraySet(field, ctx, value, v, oldSet)
+	}
+
+	// Add Scanner implementation
+	if _, ok := reflect.New(field.FieldType).Interface().(sql.Scanner); !ok {
+		field.NewValuePool = &sync.Pool{
+			New: func() interface{} {
+				return &arrayScanner{
+					fieldType: field.FieldType,
+				}
+			},
+		}
+	}
+
+	return nil
+}
+
+func (h *PostgresArrayHandler) convertArrayToPostgres(value interface{}) (interface{}, bool) {
+	switch slice := value.(type) {
+	case []string:
+		return "{" + strings.Join(slice, ",") + "}", false
+	case []int:
+		strs := make([]string, len(slice))
+		for i, v := range slice {
+			strs[i] = strconv.FormatInt(int64(v), 10)
+		}
+		return "{" + strings.Join(strs, ",") + "}", false
+	case []int8:
+		strs := make([]string, len(slice))
+		for i, v := range slice {
+			strs[i] = strconv.FormatInt(int64(v), 10)
+		}
+		return "{" + strings.Join(strs, ",") + "}", false
+	case []int16:
+		strs := make([]string, len(slice))
+		for i, v := range slice {
+			strs[i] = strconv.FormatInt(int64(v), 10)
+		}
+		return "{" + strings.Join(strs, ",") + "}", false
+	case []int32:
+		strs := make([]string, len(slice))
+		for i, v := range slice {
+			strs[i] = strconv.FormatInt(int64(v), 10)
+		}
+		return "{" + strings.Join(strs, ",") + "}", false
+	case []int64:
+		strs := make([]string, len(slice))
+		for i, v := range slice {
+			strs[i] = strconv.FormatInt(v, 10)
+		}
+		return "{" + strings.Join(strs, ",") + "}", false
+	case []uint:
+		strs := make([]string, len(slice))
+		for i, v := range slice {
+			strs[i] = strconv.FormatUint(uint64(v), 10)
+		}
+		return "{" + strings.Join(strs, ",") + "}", false
+	case []uint16:
+		strs := make([]string, len(slice))
+		for i, v := range slice {
+			strs[i] = strconv.FormatUint(uint64(v), 10)
+		}
+		return "{" + strings.Join(strs, ",") + "}", false
+	case []uint32:
+		strs := make([]string, len(slice))
+		for i, v := range slice {
+			strs[i] = strconv.FormatUint(uint64(v), 10)
+		}
+		return "{" + strings.Join(strs, ",") + "}", false
+	case []uint64:
+		strs := make([]string, len(slice))
+		for i, v := range slice {
+			strs[i] = strconv.FormatUint(v, 10)
+		}
+		return "{" + strings.Join(strs, ",") + "}", false
+	case []float32:
+		strs := make([]string, len(slice))
+		for i, v := range slice {
+			strs[i] = strconv.FormatFloat(float64(v), 'f', -1, 32)
+		}
+		return "{" + strings.Join(strs, ",") + "}", false
+	case []float64:
+		strs := make([]string, len(slice))
+		for i, v := range slice {
+			strs[i] = strconv.FormatFloat(v, 'f', -1, 64)
+		}
+		return "{" + strings.Join(strs, ",") + "}", false
+	case []bool:
+		strs := make([]string, len(slice))
+		for i, v := range slice {
+			strs[i] = strconv.FormatBool(v)
+		}
+		return "{" + strings.Join(strs, ",") + "}", false
+	}
+	return value, false
+}
+
+func (h *PostgresArrayHandler) handleArraySet(field *schema.Field, ctx context.Context, value reflect.Value, v interface{}, oldSet func(context.Context, reflect.Value, interface{}) error) error {
+	if v == nil {
+		field.ReflectValueOf(ctx, value).Set(reflect.MakeSlice(field.FieldType.Elem(), 0, 0))
+		return nil
+	}
+
+	switch data := v.(type) {
+	case *arrayScanner:
+		if data.value != nil {
+			field.ReflectValueOf(ctx, value).Set(reflect.ValueOf(data.value))
+		}
+		return nil
+	case string:
+		// Remove the curly braces
+		str := strings.Trim(data, "{}")
+
+		// Handle empty array
+		if str == "" {
+			field.ReflectValueOf(ctx, value).Set(reflect.MakeSlice(field.FieldType.Elem(), 0, 0))
+			return nil
+		}
+
+		// Split the string into elements
+		elements := strings.Split(str, ",")
+
+		// Create a new slice with the correct type
+		slice := reflect.MakeSlice(field.FieldType.Elem(), len(elements), len(elements))
+
+		// Convert each element to the correct type
+		for i, elem := range elements {
+			elem = strings.Trim(elem, "\"") // Remove quotes if present
+			switch field.FieldType.Elem().Elem().Kind() {
+			case reflect.String:
+				slice.Index(i).SetString(elem)
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				if val, err := strconv.ParseInt(elem, 10, 64); err == nil {
+					slice.Index(i).SetInt(val)
+				}
+			case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+				if val, err := strconv.ParseUint(elem, 10, 64); err == nil {
+					slice.Index(i).SetUint(val)
+				}
+			case reflect.Float32:
+				if val, err := strconv.ParseFloat(elem, 32); err == nil {
+					slice.Index(i).SetFloat(val)
+				}
+			case reflect.Float64:
+				if val, err := strconv.ParseFloat(elem, 64); err == nil {
+					slice.Index(i).SetFloat(val)
+				}
+			case reflect.Bool:
+				if val, err := strconv.ParseBool(elem); err == nil {
+					slice.Index(i).SetBool(val)
+				}
+			}
+		}
+		field.ReflectValueOf(ctx, value).Set(slice)
+		return nil
+	default:
+		return oldSet(ctx, value, v)
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

Hi @jinzhu and team, please review when you have a moment. Any feedbacks are welcome. Thanks!

### What did this pull request do?
Handle postgres array types

### User Case Description
Currently, when we we have column with array type in postgres database, we need to use or create custom type in our go program so that our program (with gorm) can map the type from/to database.

For example, we can't do this by default, because gorm will throw something like `unsupported data type: &[]`

```
type Country string

type Player struct {
	...
	Country               []Country `gorm:"type:text[]"`
}
```

we need to create custom type, for instance: 

```
type CountryArray []Country

func (a *CountryArray) Scan(src interface{}) error {
	var asBytes []byte
	switch v := src.(type) {
	case []byte:
		asBytes = v
	case string:
		asBytes = []byte(v)
	default:
		return errors.New("Scan source was not []bytes or string")
	}

	str := string(asBytes)
	parsed := strings.Trim(str, "{}")
	split := strings.Split(parsed, ",")

	*a = make(CountryArray, 0)
	for _, s := range split {
		if s == "" {
			continue
		}
		day, err := value_object.NewDayOfWeekFromString(s)
		if err != nil {
			return err
		}
		*a = append(*a, *day)
	}

	return nil
}

func (a CountryArray) Value() (driver.Value, error) {
	strArr := make([]string, len(a))
	for i, day := range a {
		strArr[i] = day.String()
	}
	return "{" + strings.Join(strArr, ",") + "}", nil
}
```

Then, use it in the model
```
type Country string

type Player struct {
	...
	Country               CountryArray `gorm:"type:text[]"`
}
```

---

By this PR, we can just implement like this, without having to use/create custom type for each array column
```
type Country string

type Player struct {
	...
	Country               []Country `gorm:"type:text[]"`
}
```
to achieve this, we just need to enable it via config
```
postgres.Config{
	...,
	EnableArrayHandler:   true,
}
```

### Compatibility and Tests

The logic of array handling is placed specifically on postgres driver so that gorm core remains clean, extensible, and database-agnostic. Since a new gorm core test case depends on new changes on postgres driver (which is new config attribute), we need to make sure that changes on postgres driver must be merged before changes on gorm core. However, it is fine if they are not merged simulatenously since this is backward compatible

<details><summary>Tests</summary>
New gorm core using new postgres driver
<img width="800" alt="Screenshot 2025-01-01 at 16 00 46" src="https://github.com/user-attachments/assets/473cfcc7-c18e-48a8-891c-ed8ed14ea28d" />

Existing gorm core using new postgres driver
<img width="929" alt="Screenshot 2025-01-01 at 16 04 26" src="https://github.com/user-attachments/assets/fdf470dd-b8e6-4c3e-a64f-594a5296022b" />

</details> 
