### PR TITLE
PG index options handle CONCURRENT option separately

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -130,7 +130,8 @@ func (m Migrator) CreateIndex(value interface{}, name string) error {
 				}
 				createIndexSQL += "INDEX "
 
-				if strings.TrimSpace(strings.ToUpper(idx.Option)) == "CONCURRENTLY" {
+				hasConcurrentOption := strings.TrimSpace(strings.ToUpper(idx.Option)) == "CONCURRENTLY"
+				if hasConcurrentOption {
 					createIndexSQL += "CONCURRENTLY "
 				}
 
@@ -142,7 +143,7 @@ func (m Migrator) CreateIndex(value interface{}, name string) error {
 					createIndexSQL += " ?"
 				}
 
-				if idx.Option != "" {
+				if idx.Option != "" && !hasConcurrentOption {
 					createIndexSQL += " " + idx.Option
 				}
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ x] Do only one thing
- [x ] Non breaking API changes
- [x ] Tested

### What did this pull request do?
PR adds a check for usage of `.Options` field when creating indexes in PG.
Based on the feedback for the previous  [PR](https://github.com/go-gorm/postgres/pull/295) - PG Migrator allows the use of `.Options` to specify extra index creation options such as [concurrently](https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY).
Previous PR broke that feature. 
This is a fix.

### User Case Description
When using Postgres driver with Gorm, users can opt to provide extra directives when creating an index.
One such PG-specific directive is to create an index ["concurrently"] (https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY). Another PG driver-specific option is to specify whether for a unique index, null values should be considered distinct or not (https://www.postgresql.org/docs/current/sql-createindex.html)
Users require a mechanism to provide these extra options for index creation. For this purpose, 'gorm options' are used: https://gorm.io/docs/indexes.html

Previous PR introduced a bug where if PG user would specify  `gorm:"index:,option:CONCURRENTLY"` option, it would result in ill-formed index because the term 'CONCURRENTLY' will be used twice.
With this PR, users can use "CONCURRENTLY" created index option OR `NULLS NOT DISTINCT` option, but not both.
