### PR TITLE
Add varchar limit detection as per PostgreSQL limits

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -228,7 +228,7 @@ func (dialector Dialector) DataTypeOf(field *schema.Field) string {
 		}
 		return "decimal"
 	case schema.String:
-		if field.Size > 0 {
+		if field.Size > 0 && field.Size <= 10485760 {
 			return fmt.Sprintf("varchar(%d)", field.Size)
 		}
 		return "text"

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -1,0 +1,57 @@
+package postgres
+
+import (
+	"testing"
+"gorm.io/gorm/schema"
+)
+
+func Test_DataTypeOf(t *testing.T) {
+	type fields struct {
+		Config *Config
+	}
+	type args struct {
+		field *schema.Field
+	}
+	tests := []struct {
+		name string
+		fields fields
+		args args
+		want string
+	} {
+		{
+			name: "it should return boolean",
+			args: args{field: &schema.Field{DataType: schema.Bool}},
+			want: "boolean",
+		},
+		{
+			name: "it should return text -1",
+			args: args{field: &schema.Field{DataType: schema.String, Size: -1}},
+			want: "text",
+		},
+		{
+			name: "it should return text > 10485760",
+			args: args{field: &schema.Field{DataType: schema.String, Size: 12345678}},
+			want: "text",
+		},
+		{
+			name: "it should return varchar(100)",
+			args: args{field: &schema.Field{DataType: schema.String, Size: 100}},
+			want: "varchar(100)",
+		},
+		{
+			name: "it should return varchar(10485760)",
+			args: args{field: &schema.Field{DataType: schema.String, Size: 10485760}},
+			want: "varchar(10485760)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dialector := Dialector{
+				Config: tt.fields.Config,
+			}
+			if got := dialector.DataTypeOf(tt.args.field); got != tt.want {
+				t.Errorf("DataTypeOf() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

Add handling for string length's that exceed 10485760 so that PostgreSQL won't complain about the field length.
Add tests to confirm change.

### User Case Description

Enable PostgreSQL to store text fields that exceed 10485760 in length, which is the maximum length of a varchar as per https://www.postgresql.org/docs/current/datatype-character.html.
This is similar to MySQL and SQLServer where specific lengths trigger a difference in the used data type.
