### PR TITLE
fix: fix migrator recognizing `nextval('"table_column_seq"'::regclass)`

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -495,8 +495,8 @@ func (m Migrator) ColumnTypes(value interface{}) (columnTypes []gorm.ColumnType,
 				column.LengthValue = typeLenValue
 			}
 
-			if (strings.HasPrefix(column.DefaultValueValue.String, "nextval('") &&
-				strings.HasSuffix(column.DefaultValueValue.String, "seq'::regclass)")) || (identityIncrement.Valid && identityIncrement.String != "") {
+			autoIncrementValuePattern := regexp.MustCompile(`^nextval\('"?[^']+seq"?'::regclass\)$`)
+			if autoIncrementValuePattern.MatchString(column.DefaultValueValue.String) || (identityIncrement.Valid && identityIncrement.String != "") {
 				column.AutoIncrementValue = sql.NullBool{Bool: true, Valid: true}
 				column.DefaultValueValue = sql.NullString{}
 			}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Using `SERIAL` to create an auto-incrementing integer column will set the default value as `nextval('"table_column_seq"'::regclass)` which contains double quotes. Current codes only check cases without double quotes. This PR should fix the problem.

### User Case Description

```sql
CREATE TABLE public."User" (
	id serial NOT NULL,
	CONSTRAINT user_pk PRIMARY KEY (id)
);
```

The default value of the id column would be `nextval('"User_id_seq"'::regclass)`

Related issue https://github.com/go-gorm/gen/issues/1272