### PR TITLE
fix(Migrator): prevent nil pointer dereference in AlterColumn

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -325,14 +325,18 @@ func (m Migrator) AlterColumn(value interface{}, field string) error {
 	err := m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		if stmt.Schema != nil {
 			if field := stmt.Schema.LookUpField(field); field != nil {
-				var (
-					columnTypes, _  = m.DB.Migrator().ColumnTypes(value)
-					fieldColumnType *migrator.ColumnType
-				)
+				columnTypes, err := m.DB.Migrator().ColumnTypes(value)
+				if err != nil {
+					return err
+				}
+				var fieldColumnType *migrator.ColumnType
 				for _, columnType := range columnTypes {
 					if columnType.Name() == field.DBName {
 						fieldColumnType, _ = columnType.(*migrator.ColumnType)
 					}
+				}
+				if fieldColumnType == nil {
+					return fmt.Errorf("failed to find column type for field %s", field.DBName)
 				}
 
 				fileType := clause.Expr{SQL: m.DataTypeOf(field)}


### PR DESCRIPTION
Closes #338

## Summary

AlterColumn has two issues:
1. Error from ColumnTypes() is discarded (assigned to _)
2. fieldColumnType is dereferenced without nil check when the schema field DBName is not found in the column types result

When schema/DB drift occurs (e.g. concurrent DROP COLUMN, partially applied migration), this causes a nil pointer panic.

## Fix

- Propagate ColumnTypes() error instead of discarding it
- Add nil guard for fieldColumnType with a descriptive error message

## Test Plan

- Follow the reproduction from go-gorm/playground#849
- Before: panic at fieldColumnType.DatabaseTypeName()
- After: returns descriptive error
