### PR TITLE
fix(Migrator): add schema qualification to GetIndexes, RenameIndex, DropIndex

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -172,9 +172,10 @@ func (m Migrator) CreateIndex(value interface{}, name string) error {
 
 func (m Migrator) RenameIndex(value interface{}, oldName, newName string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
+		currentSchema, _ := m.CurrentSchema(stmt, stmt.Table)
 		return m.DB.Exec(
-			"ALTER INDEX ? RENAME TO ?",
-			clause.Column{Name: oldName}, clause.Column{Name: newName},
+			"ALTER INDEX ?.? RENAME TO ?",
+			currentSchema, clause.Column{Name: oldName}, clause.Column{Name: newName},
 		).Error
 	})
 }
@@ -187,7 +188,8 @@ func (m Migrator) DropIndex(value interface{}, name string) error {
 			}
 		}
 
-		return m.DB.Exec("DROP INDEX ?", clause.Column{Name: name}).Error
+		currentSchema, _ := m.CurrentSchema(stmt, stmt.Table)
+		return m.DB.Exec("DROP INDEX ?.?", currentSchema, clause.Column{Name: name}).Error
 	})
 }
 
@@ -743,7 +745,8 @@ func (m Migrator) GetIndexes(value interface{}) ([]gorm.Index, error) {
 
 	err := m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		result := make([]*Index, 0)
-		scanErr := m.queryRaw(indexSql, stmt.Table).Scan(&result).Error
+		currentSchema, curTable := m.CurrentSchema(stmt, stmt.Table)
+		scanErr := m.queryRaw(indexSql+" AND ct.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = ?)", curTable, currentSchema).Scan(&result).Error
 		if scanErr != nil {
 			return scanErr
 		}


### PR DESCRIPTION
Closes #226

## Problem

GetIndexes, RenameIndex, and DropIndex do not use CurrentSchema to qualify index operations. This causes incorrect results when tables reside in non-default PostgreSQL schemas.

By contrast, HasIndex, HasTable, HasColumn, and HasConstraint all call CurrentSchema/CurrentTable to filter by schema.

## Changes

- **GetIndexes**: Call CurrentSchema and add schema filter to the indexSql query
- **RenameIndex**: Schema-qualify the ALTER INDEX target using CurrentSchema
- **DropIndex**: Schema-qualify the DROP INDEX target using CurrentSchema

All three follow the same pattern already used by HasIndex and other methods in this file.